### PR TITLE
Add code handles color contorl in a non-standard way.

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
@@ -1,0 +1,129 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+--- @type st.utils
+local utils = require "st.utils"
+--- @type st.zwave.CommandClass
+local cc = require "st.zwave.CommandClass"
+--- @type st.zwave.constants
+local constants = require "st.zwave.constants"
+--- @type st.zwave.CommandClass.Basic
+local Basic = (require "st.zwave.CommandClass.Basic")({version=1,strict=true})
+--- @type st.zwave.CommandClass.SwitchColor
+local SwitchColor = (require "st.zwave.CommandClass.SwitchColor")({version=3,strict=true})
+--- @type st.zwave.CommandClass.SwitchBinary
+local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({version=2,strict=true})
+
+local CAP_CACHE_KEY = "st.capabilities." .. capabilities.colorControl.ID
+
+local EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS = {
+  { manufacturerId = 0x001E, productType = 0x0004, productId = 0x0001 }
+}
+
+local function can_handle_ezmultipli_multipurpose_sensor(opts, driver, device, ...)
+  for _, fingerprint in ipairs(EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true
+    end
+  end
+  return false
+end
+
+local function basic_report_handler(driver, device, cmd)
+  local event
+  if cmd.args.target_value ~= nil then
+    -- Target value is our best indicator of eventual state.
+    -- If we see this, it should be considered authoritative.
+    if cmd.args.target_value == SwitchBinary.value.OFF_DISABLE then
+      event = capabilities.switch.switch.off()
+      device:emit_event_for_endpoint(cmd.src_channel, capabilities.colorControl.hue(0))
+      device:emit_event_for_endpoint(cmd.src_channel, capabilities.colorControl.saturation(0))
+    else
+      event = capabilities.switch.switch.on()
+    end
+  else
+    if cmd.args.value == SwitchBinary.value.OFF_DISABLE then
+      event = capabilities.switch.switch.off()
+      device:emit_event_for_endpoint(cmd.src_channel, capabilities.colorControl.hue(0))
+      device:emit_event_for_endpoint(cmd.src_channel, capabilities.colorControl.saturation(0))
+    else
+      event = capabilities.switch.switch.on()
+    end
+  end
+
+  device:emit_event_for_endpoint(cmd.src_channel, event)
+end
+
+local function channel_value(channel)
+  local color = (channel >= 191) and 255 or 0
+  return color
+end
+
+local function set_color(driver, device, command)
+  local hue = command.args.color.hue
+  local saturation = command.args.color.saturation
+
+  local duration = constants.DEFAULT_DIMMING_DURATION
+  local r, g, b = utils.hsl_to_rgb(hue, saturation)  
+  
+  r = (r >= 191) and 255 or 0
+  g = (g >= 191) and 255 or 0
+  b = (b >= 191) and 255 or 0  
+
+  local myhue, mysaturation = utils.rgb_to_hsl(r, g, b)
+  
+  command.args.color.hue = myhue
+  command.args.color.saturation = mysaturation
+
+  device:set_field(CAP_CACHE_KEY, command)
+
+  local set = SwitchColor:Set({
+    color_components = {
+      { color_component_id=SwitchColor.color_component_id.RED, value=r },
+      { color_component_id=SwitchColor.color_component_id.GREEN, value=g },
+      { color_component_id=SwitchColor.color_component_id.BLUE, value=b },
+      { color_component_id=SwitchColor.color_component_id.WARM_WHITE, value=0 },
+      { color_component_id=SwitchColor.color_component_id.COLD_WHITE, value=0 },
+    },
+    duration=duration
+  })  
+  device:send_to_component(set, command.component)
+  local query_color = function()
+    -- Use a single RGB color key to trigger our callback to emit a color
+    -- control capability update.
+    device:send_to_component(
+      SwitchColor:Get({ color_component_id=SwitchColor.color_component_id.RED }),
+      command.component
+    )
+  end
+  device.thread:call_with_delay(constants.DEFAULT_GET_STATUS_DELAY + duration, query_color)
+end
+
+local ezmultipli_multipurpose_sensor = {
+  NAME = "EZmultiPli Multipurpose Sensor",
+  zwave_handlers = {
+    [cc.BASIC] = {
+      [Basic.REPORT] = basic_report_handler
+    },
+  },
+  capability_handlers = {
+    [capabilities.colorControl.ID] = {
+      [capabilities.colorControl.commands.setColor.NAME] = set_color
+    }
+  },
+  can_handle = can_handle_ezmultipli_multipurpose_sensor
+}
+
+return ezmultipli_multipurpose_sensor

--- a/drivers/SmartThings/zwave-sensor/src/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/init.lua
@@ -108,7 +108,8 @@ local driver_template = {
     require("enerwave-motion-sensor"),
     require("aeotec-multisensor"),
     require("zwave-water-leak-sensor"),
-    require("everspring-motion-light-sensor")
+    require("everspring-motion-light-sensor"),
+    require("ezmultipli-multipurpose-sensor")
   },
   lifecycle_handlers = {
     added = added_handler,

--- a/drivers/SmartThings/zwave-sensor/src/test/test_ezmultipli_multipurpose_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_ezmultipli_multipurpose_sensor.lua
@@ -18,13 +18,19 @@ local zw_test_utils = require "integration_test.zwave_test_utils"
 local t_utils = require "integration_test.utils"
 local utils = require "st.utils"
 local dkjson = require "dkjson"
+local constants = require "st.zwave.constants"
+local capabilities = require "st.capabilities"
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 1 })
+local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
+local SwitchColor = (require "st.zwave.CommandClass.SwitchColor")({ version = 3 })
 
 
 local sensor_endpoints = {
     {
         command_classes = {
-            {value = zw.CONFIGURATION}
+            {value = zw.BASIC},
+            {value = zw.CONFIGURATION},
+            {value = zw.SWITCH_COLOR}
         }
     }
 }
@@ -42,6 +48,126 @@ local function test_init()
 end
 
 test.set_test_init_function(test_init)
+
+test.register_message_test(
+    "Basic report (contact sensor) should be handled",
+    {
+      {
+        channel = "zwave",
+        direction = "receive",
+        message = { mock_device.id, zw_test_utils.zwave_test_build_receive_command(Basic:Report({ value = 0xFF })) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
+      }
+    }
+)
+
+test.register_message_test(
+    "Basic report (contact sensor) should be handled",
+    {
+      {
+        channel = "zwave",
+        direction = "receive",
+        message = { mock_device.id, zw_test_utils.zwave_test_build_receive_command(Basic:Report({ value = 0x00 })) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.colorControl.hue(0))
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(0))
+      },      
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+      }
+    }
+)
+
+do
+    local hue = math.random(0, 100)
+    local sat = math.random(0, 100)
+    local r, g, b = utils.hsl_to_rgb(hue, sat)
+    r = (r >= 191) and 255 or 0
+    g = (g >= 191) and 255 or 0
+    b = (b >= 191) and 255 or 0    
+    test.register_coroutine_test(
+        "Color Control capability setColor commands should evoke the correct Z-Wave SETs and GETs",
+        function()
+            test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+            test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", command = "setColor", args = { { hue = hue, saturation = sat, level = 100 } } } })
+            
+            test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+                mock_device,
+                SwitchColor:Set({
+                    color_components = {
+                        { color_component_id = SwitchColor.color_component_id.RED, value = r },
+                        { color_component_id = SwitchColor.color_component_id.GREEN, value = g },
+                        { color_component_id = SwitchColor.color_component_id.BLUE, value = b },
+                        { color_component_id=SwitchColor.color_component_id.WARM_WHITE, value=0 },
+                        { color_component_id=SwitchColor.color_component_id.COLD_WHITE, value=0 }
+                    },
+                    duration = constants.DEFAULT_DIMMING_DURATION
+                })
+            ))
+
+            test.wait_for_events()
+            test.mock_time.advance_time(1)
+            test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+                mock_device,
+                SwitchColor:Get({ color_component_id=SwitchColor.color_component_id.RED })
+            ))
+        end
+    )
+end
+
+do
+    local hue = math.random(0, 100)
+    local sat = 100
+    local r, g, b = utils.hsl_to_rgb(hue, sat)
+    r = (r >= 191) and 255 or 0
+    g = (g >= 191) and 255 or 0
+    b = (b >= 191) and 255 or 0
+    test.register_coroutine_test(
+        "Color Control capability setColor commands should evoke the correct Z-Wave SETs and GETs",
+        function()
+            test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+            test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", command = "setColor", args = { { hue = hue, saturation = sat } } } })
+            
+            test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+                mock_device,
+                SwitchColor:Set({
+                    color_components = {
+                        { color_component_id = SwitchColor.color_component_id.RED, value = r },
+                        { color_component_id = SwitchColor.color_component_id.GREEN, value = g },
+                        { color_component_id = SwitchColor.color_component_id.BLUE, value = b },
+                        { color_component_id=SwitchColor.color_component_id.WARM_WHITE, value=0 },
+                        { color_component_id=SwitchColor.color_component_id.COLD_WHITE, value=0 }
+                    },
+                    duration = constants.DEFAULT_DIMMING_DURATION
+                })
+            ))
+
+            test.wait_for_events()
+            test.mock_time.advance_time(1)
+            test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+                mock_device,
+                SwitchColor:Get({ color_component_id=SwitchColor.color_component_id.RED })
+            ))
+        end
+    )
+end
 
 test.register_coroutine_test(
     "infoChanged() and doConfigure() should send the SET command for Configuation value",
@@ -139,6 +265,35 @@ test.register_coroutine_test(
                 Configuration:Set({parameter_number=5, size=1, configuration_value=tempAdj})
             )
         )
+
+        test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+                mock_device,
+                Basic:Get({})
+            )
+        )
+        
+        test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              SwitchColor:Get({ color_component_id=SwitchColor.color_component_id.RED })
+            )
+        )
+
+        test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              SwitchColor:Get({ color_component_id=SwitchColor.color_component_id.GREEN })
+            )
+        )
+        
+        test.socket.zwave:__expect_send(
+            zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              SwitchColor:Get({ color_component_id=SwitchColor.color_component_id.BLUE })
+            )
+        )
+
         mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end
 )


### PR DESCRIPTION
Add code handles color contorl in a non-standard way.

- add ezmultipli_multipurpose_sensor sub driver
- add basic_report_handler in the sub driver
- add set_color in the sub driver

ticket
https://smartthings.atlassian.net/browse/CHAD-5945

Signed-off-by: Keuckdo Bang <keuckdo.bang@samsung.com>